### PR TITLE
Add planner/executor/auditor stubs with tests

### DIFF
--- a/core/executor.py
+++ b/core/executor.py
@@ -1,0 +1,6 @@
+class Executor:
+    """Execute planned tasks."""
+
+    def execute(self, task):
+        """Carry out the provided ``task``."""
+        pass

--- a/core/planner.py
+++ b/core/planner.py
@@ -1,0 +1,6 @@
+class Planner:
+    """Determine the next action based on available tasks."""
+
+    def plan(self, tasks):
+        """Return the task to execute next from ``tasks``."""
+        pass

--- a/core/self_auditor.py
+++ b/core/self_auditor.py
@@ -1,0 +1,6 @@
+class SelfAuditor:
+    """Inspect results of executed tasks."""
+
+    def audit(self):
+        """Perform an audit step."""
+        pass

--- a/tests/test_executor.py
+++ b/tests/test_executor.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.executor import Executor
+
+
+def test_executor_execute():
+    executor = Executor()
+    result = executor.execute(None)
+    assert result is None

--- a/tests/test_planner.py
+++ b/tests/test_planner.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.planner import Planner
+
+
+def test_planner_plan():
+    planner = Planner()
+    result = planner.plan([])
+    assert result is None

--- a/tests/test_self_auditor.py
+++ b/tests/test_self_auditor.py
@@ -1,0 +1,11 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from core.self_auditor import SelfAuditor
+
+
+def test_self_auditor_audit():
+    auditor = SelfAuditor()
+    result = auditor.audit()
+    assert result is None


### PR DESCRIPTION
## Summary
- add minimal `Planner`, `Executor`, and `SelfAuditor` components
- test that the new components can be instantiated and their stub methods called

## Testing
- `pytest --maxfail=1 --disable-warnings -q`

------
https://chatgpt.com/codex/tasks/task_e_68525f6f18b0832a9e96fa70a188331a